### PR TITLE
Use correct call to get dataset size

### DIFF
--- a/Source/StringDataset.swift
+++ b/Source/StringDataset.swift
@@ -96,7 +96,7 @@ public class StringDataset: Dataset {
         } else {
             count = self.space.selectionSize
         }
-        let size = Int(H5Aget_storage_size(id))
+        let size = Int(H5Dget_storage_size(id))
         let stringSize = size / count
 
         var data = [CChar](repeating: 0, count: size)


### PR DESCRIPTION
H5Aget_storage_size() accepts the ID of an attribute, not a dataset, causing this call to fail:

HDF5-DIAG: Error detected in HDF5 (1.10.0) thread 0:
  #000: /Users/jonaswitt/Code/njord-player-mac/Pods/HDF5Kit/dist/src/H5A.c line 981 in H5Aget_storage_size(): not an attribute
    major: Invalid arguments to routine
    minor: Inappropriate type

H5Dget_storage_size() returns the size of a dataset, which a StringDataset is.

I found this when loading a pandas dataframe exported to HDF5, and accessing the following string dataset. The change in this PR lets me load the file/dataset without any problems. 

<img width="993" alt="screenshot 2018-10-31 at 21 26 12" src="https://user-images.githubusercontent.com/552078/47816784-5225cb00-dd54-11e8-8e56-703aa035528e.png">
<img width="993" alt="screenshot 2018-10-31 at 21 26 15" src="https://user-images.githubusercontent.com/552078/47816785-5225cb00-dd54-11e8-9e5e-ab728d15b875.png">
