### PR TITLE
StringDataset.readFixedLength() fixes

### DIFF
--- a/Source/StringDataset.swift
+++ b/Source/StringDataset.swift
@@ -100,28 +100,23 @@ public class StringDataset: Dataset {
         let stringSize = size / count
 
         var data = [CChar](repeating: 0, count: size)
-        let type = Datatype.createString(size: stringSize + 1)
+        let type = Datatype.createString(size: stringSize)
         let memspace = Dataspace(dims: [count])
         let status = H5Dread(id, type.id, memspace.id, fileSpace?.id ?? 0, 0, &data)
         if status < 0 {
             throw Error.ioError
         }
 
-        var strings = [String]()
-        strings.reserveCapacity(count)
-
-        var index = 0
-        for _ in 0..<count {
-            data.withUnsafeBufferPointer { pointer in
+        return data.withUnsafeBufferPointer { pointer in
+            var strings = [String]()
+            strings.reserveCapacity(count)
+            for idx in 0..<count {
+                let index = idx * type.size
                 let string = String(cString: pointer.baseAddress! + index)
                 strings.append(string)
-                index += string.lengthOfBytes(using: .ascii)
-                while index <= size && pointer[index] == 0 {
-                    index += 1
-                }
             }
+            return strings
         }
-        return strings
     }
 
     /// Write string data using an optional file Dataspace


### PR DESCRIPTION
It seems I spoke too soon (#26), I was still getting memory errors. This should fix them, and works fine for my example.

The Datatype must be stringSize long, not stringSize + 1, otherwise count * type.size will overrun the data array; I was getting errors like:

Njord Player(64157,0x70000ee8b000) malloc: Incorrect checksum for freed object 0x10251ba70: probably modified after being freed.
Corrupt value: 0x6e4c
Njord Player(64157,0x70000ee8b000) malloc: *** set a breakpoint in malloc_error_break to debug

Since the string size is fixed, iterating over the data array can also be done in fixed increments, without checking for null bytes in between.

Also, I made .withUnsafeBufferPointer the outer loop, as it has potentially higher costs than the for loop.