### PR TITLE
Ensure string zero padding

### DIFF
--- a/Source/StringDataset.swift
+++ b/Source/StringDataset.swift
@@ -98,9 +98,13 @@ public class StringDataset: Dataset {
         }
         let size = Int(H5Dget_storage_size(id))
         let stringSize = size / count
+        
+        // Add one extra null byte per string entry to ensure zero
+        // padding when parsing to Swift string using String(cString:) below
+        let paddedStringSize = stringSize + 1
+        let type = Datatype.createString(size: paddedStringSize)
 
-        var data = [CChar](repeating: 0, count: size)
-        let type = Datatype.createString(size: stringSize)
+        var data = [CChar](repeating: 0, count: paddedStringSize * count)
         let memspace = Dataspace(dims: [count])
         let status = H5Dread(id, type.id, memspace.id, fileSpace?.id ?? 0, 0, &data)
         if status < 0 {


### PR DESCRIPTION
So, after working with a few more test samples, I realized I half-broke string parsing in #27. 🙈 Is there a test suite for this project? 

Making the data type stringSize + 1 large was actually the better approach, but the size of the data array needs to be adjusted to avoid memory errors (not the other way round).

Since the String(cString:) initializer depends on a terminating zero character, and a fixed string may fill the entire length of its “block” in the storage space, we need to pad each string when copying it from the filespace to memspace.